### PR TITLE
Move the software stack to a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+ARG VLLM_VERSION=v0.4.2
+ARG BASE_IMAGE=vllm/vllm-openai:${VLLM_VERSION}
+FROM ${BASE_IMAGE}
+LABEL maintainer "Andrew Naylor <anaylor@lbl.gov>"
+
+# Update and Install required libs
+RUN apt-get update -y 
+RUN pip install --no-cache-dir \
+        faiss-cpu~=1.8.0 \
+        sentence-transformers~=2.5.0 \
+        whoosh \
+        gensim \
+        sfapi_client~=0.0.6 \
+        "scipy<1.13"
+
+#Add a user
+RUN groupadd -g 10001 chatbot \
+        && useradd -u 10000 -g chatbot chatbot \
+        && mkdir /home/chatbot \
+        && chown -R chatbot:chatbot /home/chatbot
+
+USER chatbot:chatbot
+
+#Start the chatbot
+# ENTRYPOINT ["python3", "-m", "chatbot"]


### PR DESCRIPTION
This PR adds a Dockerfile in order to deploy the chatbot in a container. This containerfile has been build and tested successfully with `chatbot.py` on Perlmutter. 

The build container image is available here: `docker.io/asnaylor/lmntfy:v0.3`